### PR TITLE
Client or Server Connection Compatibility

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -5,39 +5,44 @@
 In <b>Rails 3</b>, add this to your Gemfile and run the +bundle+ command.
 
   gem "ts3query"
-  
+
 == Getting Started
 
 === Connecting to a Teamspeak 3 Server
 
-  @query = TS3Query.connect :address  => "your-address.com" # default => 127.0.0.1
-                            :port     => 1234               # default => 10011
-                            :username => "myqueryuser"      # default => serveradmin
-                            :password => "myquerypassword"
+  @query = TS3Query.server_connect :address  => "your-address.com" # default => 127.0.0.1
+                                   :port     => 1234               # default => 10011
+                                   :username => "myqueryuser"      # default => serveradmin
+                                   :password => "myquerypassword"
 
-This will raise an +ConnectionRefused+ error, if the server does not response or the data are wrong.
+=== Connecting to a Teamspeak 3 Client (via ClientQuery plugin)
+
+  @query = TS3Query.client_connect :address  => "your-address.com" # default => 127.0.0.1
+                                   :port     => 1234               # default => 25639
+
+This will raise an +ConnectionRefused+ error, if the client does not respond or the credentials are wrong.
 
 === Executing query commands
 
 This retuns a result hash with all server informations.
-  
+
   result = @query.version()
-  
+
 This will return a hash with the serverlist. (Options -uid and -short)
 
   result = @query.serverlist do |opt|
-  	opt.uid
-  	opt.short
+    opt.uid
+    opt.short
   end
 
 This will select the first server. (Parameters sid=1)
 
   @query.use :sid => 1
-  
+
 You can also combine parameters and options.
 
   @query.use :sid => 1 do |opt|
-  	opt.virtual
+    opt.virtual
   end
 
 === Close the connection
@@ -45,13 +50,13 @@ You can also combine parameters and options.
 If you don't need the query connection any longer you should close it.
 
   @query.disconnect
-  
+
 === Query commands
 
 For a full command reference you can download the {Teamspeak 3 Query Manuel}[http://media.teamspeak.com/ts3_literature/TeamSpeak%203%20Server%20Query%20Manual.pdf].
 
 == Contributing to TS3Query
- 
+
 * Check out the latest master to make sure the feature hasn't been implemented or the bug hasn't been fixed yet.
 * Check out the issue tracker to make sure someone already hasn't requested it and/or contributed it.
 * Fork the project.

--- a/lib/ts3query.rb
+++ b/lib/ts3query.rb
@@ -1,15 +1,30 @@
-require 'ts3query/ts3_connection'
+require 'ts3query/server_connection'
+require 'ts3query/client_connection'
 
 module TS3Query
-  
+
+  DefaultServerParams = {
+    :address  => "127.0.0.1",
+    :port     => "10011",
+    :username => "serveradmin"
+  }
+
+  DefaultClientParams = {
+    :address  => "127.0.0.1",
+    :port     => "25639"
+  }
+
   def self.connect(params = {})
-    params = {
-      :address  => "127.0.0.1",
-      :port     => "10011",
-      :username => "serveradmin"
-    }.merge(params)
-    
-    TS3Connection.new params
+    warn "DEPRECATED(#{Kernel.caller.first}) use TS3Query.server_connect instead of TS3Query.connect"
+    server_connect params
   end
-  
+
+  def self.server_connect(params = {})
+    ServerConnection.new DefaultServerParams.merge(params)
+  end
+
+  def self.client_connect(params = {})
+    ClientConnection.new DefaultClientParams.merge(params)
+  end
+
 end

--- a/lib/ts3query/client_connection.rb
+++ b/lib/ts3query/client_connection.rb
@@ -1,0 +1,17 @@
+require 'ts3query/ts3_connection'
+
+module TS3Query
+  class ClientConnection < TS3Connection
+    private
+
+    def connect(params)
+      begin
+        @connection = Net::Telnet::new("Host" => params[:address], "Port" => params[:port])
+        @connection.waitfor("Match"   => /TS3 Client\n(.*)\n/,
+                            "Timeout" => 3)
+      rescue
+        raise ConnectionRefused, "client not available"
+      end
+    end
+  end
+end

--- a/lib/ts3query/errors.rb
+++ b/lib/ts3query/errors.rb
@@ -1,0 +1,3 @@
+module TS3Query
+  class ConnectionRefused < StandardError; end
+end

--- a/lib/ts3query/query_options.rb
+++ b/lib/ts3query/query_options.rb
@@ -1,0 +1,13 @@
+module TS3Query
+  class QueryOptions
+    attr_reader :options
+
+    def initialize
+      @options = []
+    end
+
+    def method_missing(meth, *args, &block)
+      options << meth.to_s
+    end
+  end
+end

--- a/lib/ts3query/server_connection.rb
+++ b/lib/ts3query/server_connection.rb
@@ -1,0 +1,25 @@
+require 'ts3query/ts3_connection'
+
+module TS3Query
+  class ServerConnection < TS3Connection
+    private
+
+    def connect(params)
+      begin
+        @connection = Net::Telnet::new("Host" => params[:address], "Port" => params[:port])
+        @connection.waitfor("Match"   => /TS3\n(.*)\n/,
+                            "Timeout" => 3)
+      rescue
+        raise ConnectionRefused, "server not available"
+      end
+
+      begin
+        @connection.cmd("String"  => "login client_login_name=#{params[:username]} client_login_password=#{params[:password]}\r",
+                        "Match"   => /error id=0 msg=ok\n/,
+                        "Timeout" => 3)
+      rescue
+        raise ConnectionRefused, "wrong user data"
+      end
+    end
+  end
+end

--- a/lib/ts3query/ts3_connection.rb
+++ b/lib/ts3query/ts3_connection.rb
@@ -1,89 +1,57 @@
 require 'net/telnet'
+require 'ts3query/errors'
+require 'ts3query/query_options'
 
-class TS3Connection
-  def initialize(params)
-    connect(params)
-  end
-
-  def disconnect
-    @connection.close
-  end
-
-  def method_missing(meth, *args, &block)
-    result  = []
-    options = ""
-    params  = ""
-
-    if block
-      query_options = QueryOptions.new
-      yield query_options
-
-      query_options.options.each do |opt|
-        options += " -#{opt}"
-      end
+module TS3Query
+  class TS3Connection
+    def initialize(params)
+      connect(params)
     end
 
-    if args.first
-      args.first.each do |key, value|
-        params += " #{key}=#{value}"
-      end
+    def disconnect
+      @connection.close
     end
 
-    @connection.cmd("String"  => "#{meth}#{params}#{options}\r",
-                    "Match"   => /error id=0 msg=ok\n/,
-                    "Timeout" => 3) { |data|
-      data.force_encoding 'UTF-8'
-      data.split("|").each do |current|
-        current_data = {}
-        current.split(" ").each do |entity|
-          current_data[entity.split("=")[0]] = entity.split("=")[1]
+    def method_missing(meth, *args, &block)
+      result  = []
+      options = ""
+      params  = ""
+
+      if block
+        query_options = QueryOptions.new
+        yield query_options
+
+        query_options.options.each do |opt|
+          options += " -#{opt}"
         end
-        current_data.delete("error")
-        current_data.delete("id")
-        current_data.delete("msg")
-
-        result << current_data
       end
-    }
-    result << {"id" => "0", "msg" => "ok"}
-    result.delete({})
-    result
-  end
 
-  private
+      if args.first
+        args.first.each do |key, value|
+          params += " #{key}=#{value}"
+        end
+      end
 
-  def connect(params)
-    begin
-      @connection = Net::Telnet::new("Host" => params[:address], "Port" => params[:port])
-      @connection.waitfor("Match"   => /TS3\n(.*)\n/,
-                          "Timeout" => 3)
-    rescue
-      raise ConnectionRefused, "server not available"
-    end
-
-    begin
-      @connection.cmd("String"  => "login client_login_name=#{params[:username]} client_login_password=#{params[:password]}\r",
+      @connection.cmd("String"  => "#{meth}#{params}#{options}\r",
                       "Match"   => /error id=0 msg=ok\n/,
-                      "Timeout" => 3)
-    rescue
-      raise ConnectionRefused, "wrong user data"
+                      "Timeout" => 3) { |data|
+        data.force_encoding 'UTF-8'
+        data.split("|").each do |current|
+          current_data = {}
+          current.split(" ").each do |entity|
+            key, value = entity.split "="
+            current_data[key] = value
+          end
+          current_data.delete("error")
+          current_data.delete("id")
+          current_data.delete("msg")
+
+          result << current_data
+        end
+      }
+      result << {"id" => "0", "msg" => "ok"}
+      result.delete({})
+      result
     end
   end
-end
-
-class QueryOptions
-  def initialize
-    @options = []
-  end
-
-  def method_missing(meth, *args, &block)
-    options << meth.to_s
-  end
-
-  def options
-    @options
-  end
-end
-
-class ConnectionRefused < StandardError
 end

--- a/lib/ts3query/ts3_connection.rb
+++ b/lib/ts3query/ts3_connection.rb
@@ -32,6 +32,7 @@ class TS3Connection
     @connection.cmd("String"  => "#{meth}#{params}#{options}\r",
                     "Match"   => /error id=0 msg=ok\n/,
                     "Timeout" => 3) { |data|
+      data.force_encoding 'UTF-8'
       data.split("|").each do |current|
         current_data = {}
         current.split(" ").each do |entity|


### PR DESCRIPTION
This pull implements features suggested in #2

The key feature in this pull is the ability to connect to a TS3 Client through the default ClientQuery plugin.

API

```
TS3Query.client_connect params
TS3Query.server_connect params
```

Using `TS3Query.connect params` will print a deprecation warning, and pass the params to `server_connect` to maintain backwards compatibility.

I also broke the project into multiple files (it was a single file before). Each class/module has its own file. Each class is inside the `TS3Query` module -- before some classes were directly in the global scope. `TS3Connection` is now a base class without a `#connect` private method. `ClientConnection` and `ServerConnection` both implement the missing `#connect` private method.

**Also**, minor but important, in a separate commit I convert TS responses to UTF-8. All strings that TeamSpeak sends are UTF-8 encoded, but Net::Telnet returns an ASCII-8BIT encoded string. Forcing the encoding let the server provided UTF-8 strings work client-side without issue.
